### PR TITLE
Add cumulative energy sensors (consumed and returned) for Nature Remo E, with Energy Dashboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,22 @@ Yet another [Home Assistant](https://www.home-assistant.io) component for [Natur
   - [x] Remember previous target temperatures when switching modes back and forth
 - [x] Energy Sensor (Nature Remo E/E Lite)
   - [x] Fetch current power usage
+  - [x] Fetch cumulative consumed energy
+  - [x] Fetch cumulative returned energy (for solar panels, etc.)
 - [ ] Switch
 - [ ] Light
 - [ ] TV
 - [x] Others
   - [x] Fetch sensor data
 
-Tested on Home Assistant Core 2021.3.3 on Docker
+Tested on Home Assistant Core 2024.3.4 (Linux)  
+Only energy sensor features (including cumulative consumed and returned energy) have been tested.  
+Other device features (e.g. air conditioners, switches) were not verified in this update.
+
+## Home Assistant Energy Dashboard support
+
+This integration supports Home Assistant's [Energy Dashboard](https://www.home-assistant.io/docs/energy/).
+If you're using Nature Remo E or E Lite, cumulative energy sensors (both consumed and returned) will automatically be available for configuration.
 
 ## Installation
 

--- a/sensor.py
+++ b/sensor.py
@@ -172,13 +172,13 @@ class NatureRemoReturnedEnergySensor(NatureRemoBase, SensorEntity):
             12: 1000,
         }
 
+        value = props.get(227, 0)
+        coefficient = props.get(211, 1)
+        unit_code = int(props.get(225, 0))
+        unit = unit_table.get(unit_code, 1)
+
         try:
-            if 211 in props and 225 in props and 227 in props:
-                energy = props[227] * props[211] * unit_table[int(props[225])]
-            elif 225 in props and 227 in props:
-                energy = props[227] * unit_table[int(props[225])]
-            else:
-                energy = props.get(227)
+            energy = value * coefficient * unit
             return energy
         except Exception as e:
             _LOGGER.warning("Failed to calculate returned energy: %s", e)
@@ -200,11 +200,7 @@ class NatureRemoReturnedEnergySensor(NatureRemoBase, SensorEntity):
     def unique_id(self):
         return f"{self._appliance_id}-cumulative-returned-energy"
 
-    @property
-    def extra_state_attributes(self):
-        return {
-            "calc_mode": self.calc_mode
-        }
+
 
     async def async_added_to_hass(self):
         self.async_on_remove(self._coordinator.async_add_listener(self.async_write_ha_state))

--- a/sensor.py
+++ b/sensor.py
@@ -5,7 +5,9 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import (SensorDeviceClass,
                                                    UnitOfPower,
                                                    UnitOfTemperature,
-                                                   UnitOfEnergy)
+                                                   UnitOfEnergy,
+                                                   SensorStateClass
+                                                   )
 
 from . import DOMAIN, NatureRemoBase, NatureRemoDeviceBase
 

--- a/sensor.py
+++ b/sensor.py
@@ -151,6 +151,10 @@ class NatureRemoEnergySensor(NatureRemoBase, SensorEntity):
         return SensorStateClass.TOTAL_INCREASING
     
     @property
+    def unique_id(self):
+        return f"{self._appliance_id}-cumulative-energy"
+    
+    @property
     def extra_state_attributes(self):
         return {
             "calc_mode": self.calc_mode

--- a/sensor.py
+++ b/sensor.py
@@ -140,6 +140,13 @@ class NatureRemoEnergySensor(NatureRemoBase, SensorEntity):
     @property
     def unique_id(self):
         return f"{self._appliance_id}-cumulative-energy"
+    
+    @property
+    def available(self):
+        appliance = self._coordinator.data["appliances"][self._appliance_id]
+        smart_meter = appliance["smart_meter"]
+        epcs = {int(p["epc"]) for p in smart_meter["echonetlite_properties"]}
+        return 224 in epcs
 
     async def async_added_to_hass(self):
         self.async_on_remove(self._coordinator.async_add_listener(self.async_write_ha_state))
@@ -200,8 +207,13 @@ class NatureRemoReturnedEnergySensor(NatureRemoBase, SensorEntity):
     def unique_id(self):
         return f"{self._appliance_id}-cumulative-returned-energy"
 
-
-
+    @property
+    def available(self):
+        appliance = self._coordinator.data["appliances"][self._appliance_id]
+        smart_meter = appliance["smart_meter"]
+        epcs = {int(p["epc"]) for p in smart_meter["echonetlite_properties"]}
+        return 227 in epcs
+    
     async def async_added_to_hass(self):
         self.async_on_remove(self._coordinator.async_add_listener(self.async_write_ha_state))
 

--- a/sensor.py
+++ b/sensor.py
@@ -4,7 +4,8 @@ import logging
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import (SensorDeviceClass,
                                                    UnitOfPower,
-                                                   UnitOfTemperature)
+                                                   UnitOfTemperature,
+                                                   UnitOfEnergy)
 
 from . import DOMAIN, NatureRemoBase, NatureRemoDeviceBase
 

--- a/sensor.py
+++ b/sensor.py
@@ -164,13 +164,13 @@ class NatureRemoCumulativeEnergySensorBase(NatureRemoBase, SensorEntity):
 
 
 class NatureRemoEnergySensor(NatureRemoCumulativeEnergySensorBase):
-    _epc = 224
-    _sensor_type = "Consumed"
+    def __init__(self, coordinator, appliance):
+        super().__init__(coordinator, appliance, epc=224, sensor_type="Consumed")
 
 
 class NatureRemoReturnedEnergySensor(NatureRemoCumulativeEnergySensorBase):
-    _epc = 227
-    _sensor_type = "Returned"
+    def __init__(self, coordinator, appliance):
+        super().__init__(coordinator, appliance, epc=227, sensor_type="Returned")
 
 
 class NatureRemoTemperatureSensor(NatureRemoDeviceBase, SensorEntity):

--- a/sensor.py
+++ b/sensor.py
@@ -28,9 +28,12 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     for appliance in appliances.values():
         if appliance["type"] == "EL_SMART_METER":
             entities.append(NatureRemoE(coordinator, appliance))
-            entities.append(NatureRemoEnergySensor(coordinator, appliance))
-            entities.append(NatureRemoReturnedEnergySensor(coordinator, appliance))
-
+            # Check for EPC 224 (Consumed Energy)
+            if any(prop.get("epc") == 224 for prop in appliance.get("echonetlite_properties", [])):
+                entities.append(NatureRemoEnergySensor(coordinator, appliance))
+            # Check for EPC 227 (Returned Energy)
+            if any(prop.get("epc") == 227 for prop in appliance.get("echonetlite_properties", [])):
+                entities.append(NatureRemoReturnedEnergySensor(coordinator, appliance))
     for device in devices.values():
         # skip devices that include in appliances
         if device["id"] in [appliance["device"]["id"] for appliance in appliances.values()]:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds support for cumulative energy sensors to the Nature Remo E / E Lite integration:

- `NatureRemoEnergySensor`: Cumulative consumed energy (EPC 224)
- `NatureRemoReturnedEnergySensor`: Cumulative returned energy (EPC 227)
- Compatible with Home Assistant Energy Dashboard
- Sensors share a common base class and energy calculation logic

Default values are used when coefficient or unit EPCs are missing, following Nature's API documentation.

### Additional context

Only the energy-related sensors were tested in this update.  
Other features (e.g. air conditioner control) were not verified.  
Note: The returned energy sensor has not been tested with actual solar generation environments.  
Its logic is shared with the consumed energy sensor, and is assumed to work as expected.
This implementation has been tested on Home Assistant Core 2024.3.4 (Linux).  
Feedback is welcome!

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

