### PR TITLE
fix: detect EPC 224/227 from smart_meter.echonetlite_properties

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -38,9 +38,9 @@ async def async_setup_platform(
             entities.append(NatureRemoE(coordinator, appliance))
 
             echonetlite_properties = appliance.get("smart_meter", {}).get(
-            "echonetlite_properties", []
-        )
-            
+                "echonetlite_properties", []
+            )
+
             # Check for EPC 224 (Consumed Energy)
             if any(prop.get("epc") == 224 for prop in echonetlite_properties):
                 entities.append(NatureRemoEnergySensor(coordinator, appliance))

--- a/sensor.py
+++ b/sensor.py
@@ -36,11 +36,16 @@ async def async_setup_platform(
     for appliance in appliances.values():
         if appliance["type"] == "EL_SMART_METER":
             entities.append(NatureRemoE(coordinator, appliance))
+
+            echonetlite_properties = appliance.get("smart_meter", {}).get(
+            "echonetlite_properties", []
+        )
+            
             # Check for EPC 224 (Consumed Energy)
-            if any(prop.get("epc") == 224 for prop in appliance.get("echonetlite_properties", [])):
+            if any(prop.get("epc") == 224 for prop in echonetlite_properties):
                 entities.append(NatureRemoEnergySensor(coordinator, appliance))
             # Check for EPC 227 (Returned Energy)
-            if any(prop.get("epc") == 227 for prop in appliance.get("echonetlite_properties", [])):
+            if any(prop.get("epc") == 227 for prop in echonetlite_properties):
                 entities.append(NatureRemoReturnedEnergySensor(coordinator, appliance))
     for device in devices.values():
         # skip devices that include in appliances


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix smart meter property lookup for energy sensors.

The previous implementation checked `echonetlite_properties` directly on the appliance object. However, according to the Nature Remo API structure, these properties are nested under the `smart_meter` object.

This change updates the lookup path to:

appliance["smart_meter"]["echonetlite_properties"]

This restores correct detection of:
- EPC 224 (Consumed energy)
- EPC 227 (Returned energy)


### Additional context

Repository checks described in the README were executed locally (ruff / format / pytest).

Running pytest currently reports that no tests are present in the repository, so no additional tests were added as part of this change.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
